### PR TITLE
update puppet strings to version 2

### DIFF
--- a/onceover-codequality.gemspec
+++ b/onceover-codequality.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'onceover', '~> 3'
   spec.add_runtime_dependency 'puppet-syntax', '~> 2'
   spec.add_runtime_dependency 'puppet-lint', '~> 2'
-  spec.add_runtime_dependency 'puppet-strings', '~> 1'
+  spec.add_runtime_dependency 'puppet-strings', '~> 2'
 end


### PR DESCRIPTION
This adds support for puppet strings version 2 which fixes the issue mentioned in the readme.