### PR TITLE
Configure `PuppetSyntax.exclude_paths`

### DIFF
--- a/lib/onceover/codequality/syntax.rb
+++ b/lib/onceover/codequality/syntax.rb
@@ -7,14 +7,18 @@ class Onceover
         status = true
 
         #
-        # puppet-lint
+        # puppet-syntax
         #
 
         logger.info("Checking syntax using puppet-syntax rake task...")
         # puppet-syntax seems to assign $stdout/$stderr internally in ways that
         # prevent capturing output. As a nasty hack, run it as inline ruby and
         # capture the output from the process...
-        inline_ruby = "require 'puppet-syntax/tasks/puppet-syntax' ; Rake::Task['syntax'].invoke"
+        inline_ruby = <<-RUBY_CODE
+          require 'puppet-syntax/tasks/puppet-syntax'
+          PuppetSyntax.exclude_paths = ['vendor/**/*','spec/templates/*.erb']
+          Rake::Task['syntax'].invoke
+        RUBY_CODE
         output, s = Open3.capture2e("ruby", "-e", inline_ruby)
         ok = s.exitstatus.zero?
         status &= ok


### PR DESCRIPTION
Exclude
  * `vendor/**/*` (Fixes #2)
  * `spec/templates/*.erb` (https://github.com/dylanratcliffe/onceover#overriding-onceovers-templates)