### PR TITLE
Update dependency for puppet-syntax

### DIFF
--- a/onceover-codequality.gemspec
+++ b/onceover-codequality.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.add_runtime_dependency 'onceover', '~> 3'
-  spec.add_runtime_dependency 'puppet-syntax', '~> 2'
+  spec.add_runtime_dependency 'puppet-syntax', '~> 3'
   spec.add_runtime_dependency 'puppet-lint', '~> 2'
   spec.add_runtime_dependency 'puppet-strings', '~> 2'
 end


### PR DESCRIPTION
`puppet-module-posix-dev-r2.6` version 1.1.0 has a `'puppet-syntax', '~> 3'` dependency, which conflicts with this gem's gemspec.
This change brings them back into alignment