### PR TITLE
Revert back to puppet-lint

### DIFF
--- a/onceover-codequality.gemspec
+++ b/onceover-codequality.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'onceover', '~> 3'
   spec.add_runtime_dependency 'puppet-syntax', '~> 3'
-  spec.add_runtime_dependency 'puppetlabs-puppet-lint', '~> 5'
+  spec.add_runtime_dependency 'puppet-lint', '~> 4'
   spec.add_runtime_dependency 'puppet-strings', '~> 4'
 end


### PR DESCRIPTION
puppetlabs-puppet-lint has been yanked and official support is staying for [puppet-lint](https://rubygems.org/gems/puppet-lint).
see https://github.com/puppetlabs/puppet-lint/discussions/173#discussioncomment-7643642 & https://rubygems.org/gems/puppetlabs-puppet-lint